### PR TITLE
Install as vue component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /nbproject/
 /node_modules/
+/dist/

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ this.options = {
 - Type : String
 - Default : null
 
-#### `api.options`
+#### `api.axiosOptions`
 
 - Type : Object
 - Default : {}

--- a/README.md
+++ b/README.md
@@ -150,18 +150,14 @@ new MM({
 
 ### `input`
 
-- Type : Object
-- Default : false
-- Details : Input config.
-
-#### `input.el`
-
 - Type : String
 - Details : CSS selector string.
+- Default : empty string
 
-#### `input.multiple`
+### `multipleSelection`
 
 - Type : Boolean
+- Default : false
 
 ### `selected`
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ this.options = {
 - Type : String
 - Default : null
 
+#### `api.requestConfig`
+
+- Type : Object or Function
+- Default : null
+- Details : Will be used on each request to override the config passed to axios.
+
 #### `api.axiosOptions`
 
 - Type : Object

--- a/README.md
+++ b/README.md
@@ -55,13 +55,25 @@ This project use Javascript and :
 <script src="mm.min.js"></script>
 ```
 
+or
+```
+npm install mm
+```
+
+and
+
+```
+import { MM } from 'mm'
+require('mm/dist/style.css')
+```
+
 ### Server
 
 Media Manager is a client side tool, it will display files located on a server, it needs a web service to communicate with :
 - you can use a simple server : [mm-server](https://github.com/iutbay/mm-server),
 - or you can build your own, take a look at [API doc](doc/API.md).
 
-## Usage
+## Usage in pure JavaScript
 
 **HTML**
 ```html
@@ -97,11 +109,31 @@ new MM({
         baseUrl: 'https://server.com/api/',
         listUrl: 'list'
     },
-    input: {
-        el: '#file-input',
-        multiple: false
-    }
+    multipleSelection: false,
+    input: '#file-input'
 });
+```
+
+## Usage in a VueJS project
+
+**Vue**
+```html
+<vue-media-manager :opts="options"></vue-media-manager>
+```
+
+```javascript
+var api = {
+    baseUrl: 'https://server.com/api/',
+    listUrl: 'list'
+};
+
+this.options = {
+    api: api,
+    multipleSelection: true,
+    onSelect: function ({selected}) {
+        console.log(selected)
+    }
+}
 ```
 
 ## Options
@@ -109,7 +141,7 @@ new MM({
 ### `el`
 
 - Type : String
-- Details : CSS selector string.
+- Details : CSS selector string. Only in pure JavaScript.
 
 ### `basePath`
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ This project use Javascript and :
   - [ ] Rename / Move
   - [ ] Delete
 - [x] Context menu
-- [ ] vuejs component
-- [ ] npm package
+- [x] vuejs component
+- [x] npm package
 - [ ] Integration :
   - [ ] CKEditor plugin
   - [ ] TinyMCE plugin

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <div class="container">
         <p></p>
         <div class="row">
-            <div class="col-md-6">
+            <div class="col-md-4">
                 <h3>Single</h3>
                 <div class="form-group">
                     <div id="media-manager-1"></div>
@@ -27,13 +27,19 @@
                     <input id="file-input-1" type="text" class="form-control" placeholder="File">
                 </div>
             </div>
-            <div class="col-md-6">
+            <div class="col-md-4">
                 <h3>Multiple</h3>
                 <div class="form-group">
                     <div id="media-manager-3"></div>
                 </div>
                 <div class="form-group">
                     <textarea id="file-input-3" class="form-control" placeholder="Files"></textarea>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <h3>VueApp</h3>
+                <div class="form-group">
+                    <vue-app></vue-app>
                 </div>
             </div>
         </div>
@@ -75,6 +81,7 @@
         integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="/dist/mm.js"></script>
+    <script src="https://cdn.bootcss.com/vue/2.2.4/vue.js"></script>
 
     <script type="text/javascript">
         /* global MM, $ */
@@ -90,20 +97,16 @@
         mm1 = new MM({
             el: '#media-manager-1',
             api: api,
-            input: {
-                el: '#file-input-1',
-                multiple: false
-            }
+            input: '#file-input-1',
+            multipleSelection: false
         });
 
         mm3 = new MM({
             el: '#media-manager-3',
             basePath: '/',
             api: api,
-            input: {
-                el: '#file-input-3',
-                multiple: true
-            },
+            input: '#file-input-3',
+            multipleSelection: true,
             height: '400px'
         }); 
 
@@ -112,18 +115,38 @@
                 el: '#media-manager-2',
                 path: '/',
                 api: api,
-                input: {
-                    el: '#file-input-2',
-                    multiple: false
-                },
-                height: '400px',
-                onSelect: function(e) {
-                    $('#media-manager-modal').modal('hide');
-                }
+                input: '#file-input-2',
+                multipleSelection: false,
+                height: '400px'
             });
         });
         $('#media-manager-modal').on('hide.bs.modal', function (e) {
             mm2.destroy();
+        });
+
+        Vue.use(MM);
+
+        new Vue({
+            el: 'vue-app',
+            render: h => h({
+                template: `<vue-media-manager :opts="options"></vue-media-manager>`,
+                created() {
+                    var api = {
+                        baseUrl: 'http://localhost:8081/',
+                        listUrl: 'list.json',
+                        downloadUrl: 'download',
+                        uploadUrl: 'upload'
+                    };
+
+                    this.options = {
+                        api: api,
+                        multipleSelection: true,
+                        onSelect: function ({selected}) {
+                            console.log(selected)
+                        }
+                    }
+                },
+            })
         });
 
     </script>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "version": "0.0.1",
   "author": "Kevin LEVRON <kevin.levron@univ-pau.fr>",
   "private": false,
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iutbay/mm.git"
+  },
+  "main": "dist/mm.min.js",
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
@@ -11,6 +17,7 @@
   "dependencies": {
     "vue": "^2.2.4",
     "vuex": "^3.0.1",
+    "es6-promise": "^4.1.1",
     "axios": "^0.15.3"
   },
   "devDependencies": {
@@ -20,10 +27,11 @@
     "babel-preset-stage-3": "^6.24.1",
     "cross-env": "^5.0.5",
     "css-loader": "^0.28.7",
-    "es6-promise": "^4.1.1",
     "extract-text-webpack-plugin": "^3.0.2",
     "file-loader": "^1.1.4",
     "node-sass": "^4.5.3",
+    "postcss-import": "^11.1.0",
+    "postcss-url": "^7.3.0",
     "sass-loader": "^6.0.6",
     "vue-loader": "^13.0.5",
     "vue-template-compiler": "^2.4.4",

--- a/src/Store.js
+++ b/src/Store.js
@@ -16,7 +16,7 @@ export default class Store {
 
         return {
             state: {
-                component,
+                mm: component,
                 options: options,
                 path: options.basePath + options.path,
                 selected: selected

--- a/src/Store.js
+++ b/src/Store.js
@@ -1,0 +1,73 @@
+export default class Store {
+    static create(component, options) {
+        /*
+         * Init selected
+         */
+        let selected = options.selected;
+        if (selected) {
+            if (Array.isArray(selected)) {
+                selected = selected.map(function(e){
+                    return { path: e };
+                });
+            } else {
+                selected = { path: selected };
+            }
+        }
+
+        return {
+            state: {
+                component,
+                options: options,
+                path: options.basePath + options.path,
+                selected: selected
+            },
+            mutations: {
+                resetSelected(state) {
+                    state.selected = null;
+                },
+                addSelected(state, file) {
+                    if (state.options.input.multiple) {
+                        if (!Array.isArray(state.selected)) {
+                            state.selected = [];
+                        } else {
+                            let index = state.selected.findIndex(element => { return element.path === file.path; });
+                            if (index>-1) return;
+                        }
+                        state.selected.push(file);
+                    } else {
+                        state.selected = file;
+                    }
+                    state.mm.onSelect({ selected: state.selected });
+                },
+                removeSelected(state, file) {
+                    if (state.options.input.multiple) {
+                        if (!Array.isArray(state.selected)) return;
+                        let index = state.selected.findIndex(element => { return element.path === file.path; });
+                        if (index>-1)
+                            state.selected.splice(index, 1);
+                    } else {
+                        state.selected = null;
+                    }
+                    state.mm.onSelect({ selected: state.selected });
+                }
+            },
+            getters: {
+                isSelected: (state, getters) => (file) => {
+                    //if (!state.options.input) return false;
+                    if (state.options.input.multiple) {
+                        if (!Array.isArray(state.selected)) return;
+                        let index = state.selected.findIndex(element => { return element.path === file.path; });
+                        return index > -1;
+                    } else {
+                        return (state.selected && state.selected.path === file.path);
+                    }
+                },
+                nbSelected: (state, getters) => {
+                    if (Array.isArray(state.selected)) return state.selected.length;
+                    if (state.selected) return 1;
+                    return 0;
+                }
+            }
+        }
+    }
+}

--- a/src/Store.js
+++ b/src/Store.js
@@ -26,7 +26,7 @@ export default class Store {
                     state.selected = null;
                 },
                 addSelected(state, file) {
-                    if (state.options.input.multiple) {
+                    if (state.options.multipleSelection) {
                         if (!Array.isArray(state.selected)) {
                             state.selected = [];
                         } else {
@@ -40,7 +40,7 @@ export default class Store {
                     state.mm.onSelect({ selected: state.selected });
                 },
                 removeSelected(state, file) {
-                    if (state.options.input.multiple) {
+                    if (state.options.multipleSelection) {
                         if (!Array.isArray(state.selected)) return;
                         let index = state.selected.findIndex(element => { return element.path === file.path; });
                         if (index>-1)
@@ -54,7 +54,7 @@ export default class Store {
             getters: {
                 isSelected: (state, getters) => (file) => {
                     //if (!state.options.input) return false;
-                    if (state.options.input.multiple) {
+                    if (state.options.multipleSelection) {
                         if (!Array.isArray(state.selected)) return;
                         let index = state.selected.findIndex(element => { return element.path === file.path; });
                         return index > -1;

--- a/src/api.js
+++ b/src/api.js
@@ -23,11 +23,24 @@ export default class Api {
     }
 
     list(path) {
-        return this.axios.get(this.options.listUrl, { params: { path: path } });
+        var conf = this.computeConfig({ params: { path: path } });
+        return this.axios.get(this.options.listUrl, conf);
     }
 
     upload(data, config) {
-        return this.axios.post(this.options.uploadUrl, data, config);
+        var conf = this.computeConfig(config);
+        return this.axios.post(this.options.uploadUrl, data, conf);
+    }
+
+    computeConfig(conf) {
+        if (!this.options.requestConfig) {
+            return conf
+        }
+        var overrideConf = this.options.requestConfig
+        if (overrideConf instanceof Function) {
+            overrideConf = overrideConf()
+        }
+        return { ...conf, ...overrideConf }
     }
 
     downloadUrl(file) {

--- a/src/api.js
+++ b/src/api.js
@@ -23,7 +23,7 @@ export default class Api {
     }
 
     list(path) {
-        return this.axios.get(this.options.listUrl, { params: { path: this.path } });
+        return this.axios.get(this.options.listUrl, { params: { path: path } });
     }
 
     upload(data, config) {

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -52,16 +52,20 @@ export default {
         if (this.options.onCreated)
             this.options.onCreated({ vc: this });
 
-        /*
-         * Input options ?
-         */
-        if (this.options.input) {
-            this.input = document.querySelector(this.options.input);
-        }
+        this._input = null;
     },
     computed: {
         overrideOptions () {
             return { ...defaultOptions, ...this.options }
+        },
+        input () {
+            /*
+            * Input options ?
+            */
+            if (!this._input && this.options.input) {
+                this._input = document.querySelector(this.options.input);
+            }
+            return this._input;
         }
     },
     methods: {

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -27,7 +27,8 @@ const defaultOptions = {
         uploadUrl: null,
         options: {}
     },
-    input: false,
+    input: '',
+    multipleSelection: false,
     onCreated: null,
     onMounted: null,
     onSelect: null,
@@ -55,10 +56,7 @@ export default {
          * Input options ?
          */
         if (this.options.input) {
-            this.input = {
-                el: document.querySelector(this.options.input.el),
-                multiple: this.options.input.multiple
-            };
+            this.input = document.querySelector(this.options.input);
         }
     },
     computed: {
@@ -70,14 +68,14 @@ export default {
         onSelect(e) {
             if (this.input) {
                 if (e.selected) {
-                    if (this.input.multiple) {
+                    if (this.options.multipleSelection) {
                         let selected = e.selected.map(element => { return element.path; });
-                        this.input.el.value = selected.join("\n");
+                        this.input.value = selected.join("\n");
                     } else {
-                        this.input.el.value = e.selected.path;
+                        this.input.value = e.selected.path;
                     }
                 } else {
-                    this.input.el.value = '';
+                    this.input.value = '';
                 }
             }
 

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -10,19 +10,27 @@
 
 <script>
 import MediaManager from './MediaManager.vue';
+import Api from '../api.js';
 
 export default {
     components: { MediaManager },
-    props: [ 'id' ],
+    props: [ 'id', 'options' ],
     created() {
-        this.$root.id = this.id;
-        this.$mm.onCreated({ vc: this });
+
+        /*
+         * Init api
+         */
+        this.api = new Api(this.options.api);
+
+        if (this.options.onCreated)
+            this.options.onCreated({ vc: this });
     },
     mounted() {
-        this.$mm.onMounted({ el: this.$el, vc: this });
+        if (this.options.onMounted)
+            this.options.onMounted({ el: this.$el, vc: this });
     }
 };
-</script>        
+</script>
 
 <style src="../assets/css/style.scss" lang="scss">
 </style>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -2,21 +2,21 @@
 
     <div class="media-manager" v-bind:id="id">
 
-        <media-manager></media-manager>
+        <div ref="mediaManager"></div>
 
     </div>
 
 </template>
 
 <script>
+import Vue from 'vue';
 import MediaManager from './MediaManager.vue';
 import Api from '../api.js';
 
 export default {
     components: { MediaManager },
-    props: [ 'id', 'options' ],
+    props: [ 'id', 'options' , 'store'],
     created() {
-
         /*
          * Init api
          */
@@ -28,6 +28,19 @@ export default {
     mounted() {
         if (this.options.onMounted)
             this.options.onMounted({ el: this.$el, vc: this });
+        
+        var mediaManager = this.$refs.mediaManager
+
+        new Vue({
+            el: mediaManager,
+            store: this.store,
+            render: h => h(MediaManager, {
+                props: {
+                    id: this.id,
+                    api: this.api
+                }
+            })
+        });
     }
 };
 </script>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -10,13 +10,39 @@
 
 <script>
 import Vue from 'vue';
+import Vuex from 'vuex';
 import MediaManager from './MediaManager.vue';
 import Api from '../api.js';
+import Store from '../Store'
+
+Vue.use(Vuex);
+
+const defaultOptions = {
+    basePath: '',
+    path: '',
+    api: {
+        baseUrl: null,
+        listUrl: null,
+        downloadUrl: null,
+        uploadUrl: null,
+        options: {}
+    },
+    input: false,
+    onCreated: null,
+    onMounted: null,
+    onSelect: null,
+    showBreadcrumb: true,
+    height: null,
+    vue: Vue,
+    asVueComponenet: false
+}
 
 export default {
     components: { MediaManager },
-    props: [ 'id', 'options' , 'store'],
+    props: [ 'id', 'opts'],
     created() {
+        this.options = { ...defaultOptions, ...this.opts };
+
         /*
          * Init api
          */
@@ -24,16 +50,52 @@ export default {
 
         if (this.options.onCreated)
             this.options.onCreated({ vc: this });
+
+        /*
+         * Input options ?
+         */
+        if (this.options.input) {
+            this.input = {
+                el: document.querySelector(this.options.input.el),
+                multiple: this.options.input.multiple
+            };
+        }
+    },
+    computed: {
+        overrideOptions () {
+            return { ...defaultOptions, ...this.options }
+        }
+    },
+    methods: {
+        onSelect(e) {
+            if (this.input) {
+                if (e.selected) {
+                    if (this.input.multiple) {
+                        let selected = e.selected.map(element => { return element.path; });
+                        this.input.el.value = selected.join("\n");
+                    } else {
+                        this.input.el.value = e.selected.path;
+                    }
+                } else {
+                    this.input.el.value = '';
+                }
+            }
+
+            if (this.options.onSelect)
+                this.options.onSelect(e);
+        }
     },
     mounted() {
         if (this.options.onMounted)
             this.options.onMounted({ el: this.$el, vc: this });
+
+        const store = new Vuex.Store(Store.create(this, this.options));
         
         var mediaManager = this.$refs.mediaManager
 
         new Vue({
             el: mediaManager,
-            store: this.store,
+            store,
             render: h => h(MediaManager, {
                 props: {
                     id: this.id,

--- a/src/components/DetailsWidget.vue
+++ b/src/components/DetailsWidget.vue
@@ -40,7 +40,7 @@
                 <p class="buttons">
                     <button v-on:click.prevent="onClose" class="btn btn-default btn-sm" role="button"><i class="fa fa-times" aria-hidden="true"></i> Close</button>
                     <template v-if="file.type!='dir'">
-                        <a v-if="$api.downloadUrl(file)" v-bind:href="$api.downloadUrl(file)" class="btn btn-primary btn-sm" role="button"><i class="fa fa-download" aria-hidden="true"></i> Download</a>
+                        <a v-if="api.downloadUrl(file)" v-bind:href="api.downloadUrl(file)" class="btn btn-primary btn-sm" role="button"><i class="fa fa-download" aria-hidden="true"></i> Download</a>
                         <button v-if="mmc.isSelected(file)" v-on:click.prevent="onUnselect"class="btn btn-primary btn-sm" role="button"><i class="fa fa-times" aria-hidden="true"></i> Unselect</button>
                         <button v-else v-on:click.prevent="onSelect"class="btn btn-primary btn-sm" role="button"><i class="fa fa-check" aria-hidden="true"></i> Select</button>
                     </template>
@@ -62,7 +62,10 @@ export default {
             options: state => state.options
         }),
         mmc() {
-            return this.$root.$mmc;
+            return this.$parent;
+        },
+        api () {
+            return this.mmc.api;
         }
     },
     methods: {

--- a/src/components/MediaManager.vue
+++ b/src/components/MediaManager.vue
@@ -82,6 +82,7 @@ import DetailsWidget from './DetailsWidget.vue';
 import NotificationWidget from './NotificationWidget.vue';
 
 export default {
+    props: ['api', 'id'],
     components: {
         MediasWidget,
         UploadWidget,
@@ -122,12 +123,6 @@ export default {
             }
 
             return breadcrumb;
-        },
-        api () {
-            return this.$parent.api;
-        },
-        id () {
-            return this.$parent.id;
         }
     },
     created() {

--- a/src/components/MediaManager.vue
+++ b/src/components/MediaManager.vue
@@ -46,7 +46,7 @@
                 <div class="mm-content">
 
                     <upload-widget
-                        v-if="$api.options.uploadUrl"
+                        v-if="api.options.uploadUrl"
                         v-bind:path="path"
                         v-show="showUpload"
                         v-on:upload-success="onUploadSuccess"
@@ -122,10 +122,15 @@ export default {
             }
 
             return breadcrumb;
+        },
+        api () {
+            return this.$parent.api;
+        },
+        id () {
+            return this.$parent.id;
         }
     },
     created() {
-        this.$root.$mmc = this;
     },
     methods: {
 

--- a/src/components/MediaWidget.vue
+++ b/src/components/MediaWidget.vue
@@ -45,7 +45,7 @@ export default {
     props: [ 'file' ],
     computed: {
         mmc() {
-            return this.$root.$mmc;
+            return this.$parent.$parent;
         }
     },
     methods: {

--- a/src/components/MediasWidget.vue
+++ b/src/components/MediasWidget.vue
@@ -60,7 +60,7 @@
                         <li v-if="mmc.isSelected(contextMenuFile)"><a v-on:click.prevent="mmc.unselectFile(contextMenuFile)" href="#"><i class="fa fa-fw fa-times"></i> Unselect</a></li>
                         <li v-else><a v-on:click.prevent="mmc.selectFile(contextMenuFile)" href="#"><i class="fa fa-fw fa-check"></i> Select</a></li>
                         <li><a v-on:click.prevent="mmc.toggleDetailsOn(contextMenuFile)" href="#"><i class="fa fa-fw fa-info-circle"></i> Details</a></li>
-                        <li><a v-bind:href="$api.downloadUrl(contextMenuFile)"><i class="fa fa-fw fa-download"></i> Download</a></li>
+                        <li><a v-bind:href="api.downloadUrl(contextMenuFile)"><i class="fa fa-fw fa-download"></i> Download</a></li>
                     </ul>
                 </div>
             </transition>
@@ -95,7 +95,10 @@ export default {
             basePath: state => state.options.basePath
         }),
         mmc() {
-            return this.$root.$mmc;
+            return this.$parent;
+        },
+        api () {
+            return this.mmc.api;
         },
         relPath() {
             return this.path.replace(this.basePath, '');
@@ -124,7 +127,7 @@ export default {
             this.loading = true;
             this.error = false;
             
-            this.$api.list(this.path)
+            this.api.list(this.path)
                 .then(response => {
                     if (Array.isArray(response.data)) {
                         response.data.sort((a, b) => {

--- a/src/components/UploadStatusWidget.vue
+++ b/src/components/UploadStatusWidget.vue
@@ -47,7 +47,7 @@ export default {
     props: [ 'uploads' ],
     computed: {
         mmc() {
-          return this.$root.$mmc;
+          return this.$parent;
         },
         completed() {
             let upload;

--- a/src/components/UploadWidget.vue
+++ b/src/components/UploadWidget.vue
@@ -50,10 +50,13 @@ export default {
     props: ['path'],
     computed: {
         mmc() {
-          return this.$root.$mmc;
+          return this.$parent;
+        },
+        api () {
+            return this.mmc.api;
         },
         fileInputId() {
-            return this.$root.id+'-file-input';
+            return this.mmc.id+'-file-input';
         }
     },
     mounted() {
@@ -142,7 +145,7 @@ export default {
             formData.append('path', this.path);
             formData.append('file', file);
 
-            return this.$api.upload(formData, {
+            return this.api.upload(formData, {
                 onUploadProgress: progressEvent => {
                    let upload = this.mmc.uploads[file.index];
                    upload.loaded = progressEvent.loaded;

--- a/src/main.js
+++ b/src/main.js
@@ -3,12 +3,15 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import App from './components/App.vue';
 
-import Api from './api.js';
-
 /**
  * Media Manager
  */
 export class MM {
+
+    static install (Vue, options) {
+        options.vue = Vue;
+        var instance = new MM(options);
+    }
 
     static get defaultOptions() {
         return {
@@ -26,7 +29,9 @@ export class MM {
             onMounted: null,
             onSelect: null,
             showBreadcrumb: true,
-            height: null
+            height: null,
+            vue: Vue,
+            asVueComponenet: false
         };
     }
 
@@ -60,11 +65,6 @@ export class MM {
                 selected = { path: selected };
             }
         }
-
-        /*
-         * Init api
-         */
-        Vue.prototype.$api = new Api(this.options.api);
 
         /*
          * Init Vuex
@@ -131,25 +131,17 @@ export class MM {
         /*
          * Init Vue
          */
-        Vue.prototype.$mm = this;
         let el = document.querySelector(this.options.el);
         this.vm = new Vue({
             el: this.options.el,
             store,
             render: h => h(App, {
-                props: { id: el.id }
+                props: {
+                    id: el.id,
+                    options: this.options
+                }
             })
         });
-    }
-
-    onCreated(e) {
-        if (this.options.onCreated)
-            this.options.onCreated(e);
-    }
-
-    onMounted(e) {
-        if (this.options.onMounted)
-            this.options.onMounted(e);
     }
 
     onSelect(e) {

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import 'es6-promise/auto';
 import Vue from 'vue';
 import Vuex from 'vuex';
 import App from './components/App.vue';
+import Store from './Store'
 
 /**
  * Media Manager
@@ -53,80 +54,11 @@ export class MM {
         }
 
         /*
-         * Init selected
-         */
-        let selected = this.options.selected;
-        if (selected) {
-            if (Array.isArray(selected)) {
-                selected = selected.map(function(e){
-                    return { path: e };
-                });
-            } else {
-                selected = { path: selected };
-            }
-        }
-
-        /*
          * Init Vuex
          */
         let mm = this;
         Vue.use(Vuex);
-        const store = new Vuex.Store({
-            state: {
-                mm,
-                options: this.options,
-                path: this.options.basePath + this.options.path,
-                selected: selected
-            },
-            mutations: {
-                resetSelected(state) {
-                    state.selected = null;
-                },
-                addSelected(state, file) {
-                    if (state.options.input.multiple) {
-                        if (!Array.isArray(state.selected)) {
-                            state.selected = [];
-                        } else {
-                            let index = state.selected.findIndex(element => { return element.path === file.path; });
-                            if (index>-1) return;
-                        }
-                        state.selected.push(file);
-                    } else {
-                        state.selected = file;
-                    }
-                    state.mm.onSelect({ selected: state.selected });
-                },
-                removeSelected(state, file) {
-                    if (state.options.input.multiple) {
-                        if (!Array.isArray(state.selected)) return;
-                        let index = state.selected.findIndex(element => { return element.path === file.path; });
-                        if (index>-1)
-                            state.selected.splice(index, 1);
-                    } else {
-                        state.selected = null;
-                    }
-                    state.mm.onSelect({ selected: state.selected });
-                }
-            },
-            getters: {
-                isSelected: (state, getters) => (file) => {
-                    //if (!state.options.input) return false;
-                    if (state.options.input.multiple) {
-                        if (!Array.isArray(state.selected)) return;
-                        let index = state.selected.findIndex(element => { return element.path === file.path; });
-                        return index > -1;
-                    } else {
-                        return (state.selected && state.selected.path === file.path);
-                    }
-                },
-                nbSelected: (state, getters) => {
-                    if (Array.isArray(state.selected)) return state.selected.length;
-                    if (state.selected) return 1;
-                    return 0;
-                }
-            }
-        });
-
+        const store = new Vuex.Store(Store.create(this, this.options));
 
         /*
          * Init Vue
@@ -138,7 +70,8 @@ export class MM {
             render: h => h(App, {
                 props: {
                     id: el.id,
-                    options: this.options
+                    options: this.options,
+                    store
                 }
             })
         });

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,6 @@
 import 'es6-promise/auto';
 import Vue from 'vue';
-import Vuex from 'vuex';
 import App from './components/App.vue';
-import Store from './Store'
 
 /**
  * Media Manager
@@ -14,85 +12,25 @@ export class MM {
         var instance = new MM(options);
     }
 
-    static get defaultOptions() {
-        return {
-            basePath: '',
-            path: '',
-            api: {
-                baseUrl: null,
-                listUrl: null,
-                downloadUrl: null,
-                uploadUrl: null,
-                options: {}
-            },
-            input: false,
-            onCreated: null,
-            onMounted: null,
-            onSelect: null,
-            showBreadcrumb: true,
-            height: null,
-            vue: Vue,
-            asVueComponenet: false
-        };
-    }
-
     constructor(opts) {
-        this.options = { ...this.constructor.defaultOptions, ...opts };
+        this.options = opts;
         this.init();
     }
 
     init() {
-
-        /*
-         * Input options ?
-         */
-        if (this.options.input) {
-            this.input = {
-                el: document.querySelector(this.options.input.el),
-                multiple: this.options.input.multiple
-            };
-        }
-
-        /*
-         * Init Vuex
-         */
-        let mm = this;
-        Vue.use(Vuex);
-        const store = new Vuex.Store(Store.create(this, this.options));
-
         /*
          * Init Vue
          */
         let el = document.querySelector(this.options.el);
         this.vm = new Vue({
             el: this.options.el,
-            store,
             render: h => h(App, {
                 props: {
                     id: el.id,
-                    options: this.options,
-                    store
+                    opts: this.options
                 }
             })
         });
-    }
-
-    onSelect(e) {
-        if (this.input) {
-            if (e.selected) {
-                if (this.input.multiple) {
-                    let selected = e.selected.map(element => { return element.path; });
-                    this.input.el.value = selected.join("\n");
-                } else {
-                    this.input.el.value = e.selected.path;
-                }
-            } else {
-                this.input.el.value = '';
-            }
-        }
-
-        if (this.options.onSelect)
-            this.options.onSelect(e);
     }
 
     destroy() {

--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,8 @@ import App from './components/App.vue';
  */
 export class MM {
 
-    static install (Vue, options) {
-        options.vue = Vue;
-        var instance = new MM(options);
+    static install (vue, options) {
+        vue.component('vue-media-manager', App)
     }
 
     constructor(opts) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,6 +91,12 @@ module.exports = {
     performance: {
         hints: false
     },
+    externals: {
+        'vue' : 'vue',
+        'vuex' : 'vuex',
+        'axios' : 'axios',
+        'es6-promise/auto': 'es6-promise/auto'
+    },
     devtool: '#eval-source-map'
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,12 +91,6 @@ module.exports = {
     performance: {
         hints: false
     },
-    externals: {
-        'vue' : 'vue',
-        'vuex' : 'vuex',
-        'axios' : 'axios',
-        'es6-promise/auto': 'es6-promise/auto'
-    },
     devtool: '#eval-source-map'
 }
 
@@ -120,4 +114,10 @@ if (PROD) {
         }),
         new ExtractTextPlugin('style.css')
     ])
+    module.exports.externals = {
+        'vue' : 'vue',
+        'vuex' : 'vuex',
+        'axios' : 'axios',
+        'es6-promise/auto': 'es6-promise/auto'
+    }
 }


### PR DESCRIPTION
Remove use of instantiate property for each component in the root Vue instance.
Move store constructor and init of store inside the app.vue

Add sample to use component inside a Vue app

Update configuration to minimize the size of mm.min.js and package.json to prepare a package to publish on NPM.

Update readme to use inside a webpack / vuejs project (need a publish on NPM).